### PR TITLE
PIP-82 - Added checks to make sure that the json state being persisted is of a valid format and fixed issue where it was not deleting persisted states under the user/<user>/ui-panel directory - it did not need the forward slash at the beginning as it uses the Amazon API which can determine this as it already knows the bucket.

### DIFF
--- a/src/main/java/org/ihtsdo/snowowl/authoring/single/api/rest/config/RestControllerAdvice.java
+++ b/src/main/java/org/ihtsdo/snowowl/authoring/single/api/rest/config/RestControllerAdvice.java
@@ -1,0 +1,35 @@
+package org.ihtsdo.snowowl.authoring.single.api.rest.config;
+
+import org.ihtsdo.snowowl.authoring.single.api.service.exceptions.PathNotProvidedException;
+import org.json.JSONException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseBody;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@ControllerAdvice
+public class RestControllerAdvice {
+
+	private static final Logger logger = LoggerFactory.getLogger(RestControllerAdvice.class);
+
+	@ExceptionHandler({
+			JSONException.class,
+			PathNotProvidedException.class
+	})
+	@ResponseStatus(HttpStatus.BAD_REQUEST)
+	@ResponseBody
+	public Map<String,Object> handleIllegalArgumentException(Exception exception) {
+		HashMap<String, Object> result = new HashMap<>();
+		result.put("error", HttpStatus.BAD_REQUEST);
+		result.put("message", exception.getMessage());
+		logger.info("bad request {}", exception.getMessage());
+		logger.debug("bad request {}", exception.getMessage(), exception);
+		return result;
+	}
+}

--- a/src/main/java/org/ihtsdo/snowowl/authoring/single/api/service/UiStateService.java
+++ b/src/main/java/org/ihtsdo/snowowl/authoring/single/api/service/UiStateService.java
@@ -4,6 +4,7 @@ import org.ihtsdo.otf.rest.exception.BusinessServiceException;
 import org.ihtsdo.otf.rest.exception.ResourceNotFoundException;
 import org.ihtsdo.snowowl.authoring.single.api.pojo.TaskTransferRequest;
 import org.ihtsdo.snowowl.authoring.single.api.service.dao.UiStateResourceService;
+import org.json.JSONObject;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
@@ -17,6 +18,9 @@ public class UiStateService {
 	private UiStateResourceService resourceService;
 
 	public void persistTaskPanelState(final String projectKey, final String taskKey, final String username, final String panelId, final String jsonState) throws IOException {
+		// Check to make sure that the state is valid JSON.
+		new JSONObject(jsonState);
+
 		resourceService.write(getTaskUserPanelPath(projectKey, taskKey, username, panelId), jsonState);
 	}
 
@@ -38,6 +42,9 @@ public class UiStateService {
 	}
 
 	public void persistPanelState(final String username, final String panelId, final String jsonState) throws IOException {
+		// Check to make sure that the state is valid JSON.
+		new JSONObject(jsonState);
+
 		resourceService.write(getUserPanelPath(username, panelId), jsonState);
 	}
 
@@ -58,7 +65,7 @@ public class UiStateService {
 	}
 
 	private String getUserPanelPath(final String username, final String panelId) {
-		return "/user/" + username + "/ui-panel/" + panelId + ".json";
+		return "user/" + username + "/ui-panel/" + panelId + ".json";
 	}
 
 	public void deleteTaskPanelState(final String projectKey, final String taskKey, final String username, final String panelId) throws IOException {

--- a/src/test/java/org/ihtsdo/snowowl/authoring/single/api/service/UiStateServiceTest.java
+++ b/src/test/java/org/ihtsdo/snowowl/authoring/single/api/service/UiStateServiceTest.java
@@ -1,0 +1,19 @@
+package org.ihtsdo.snowowl.authoring.single.api.service;
+
+import org.json.JSONException;
+import org.junit.Test;
+
+import java.io.IOException;
+
+public class UiStateServiceTest {
+
+	@Test(expected = JSONException.class)
+	public void testPersistTaskPanelStateThrowsExceptionWhenJsonStateIsMalformed() throws IOException {
+		new UiStateService().persistTaskPanelState("", "", "", "", "test}");
+	}
+
+	@Test(expected = JSONException.class)
+	public void testPersistPanelStateThrowsExceptionWhenJsonStateIsMalformed() throws IOException {
+		new UiStateService().persistTaskPanelState("", "", "", "", "{test");
+	}
+}


### PR DESCRIPTION
It was noted from Chris S that when writing the state, it doesn't check for malformed JSON so I've added in a check to make sure it will only persist states when the JSON is of a valid form. If not, it will return a 400 BAD REQUEST.

I also fixed an issue where it wasn't deleting properly from the user/`<user>`/ui-panel as it was appending a forward slash at the beginning of the path which wasn't needed due to using the Amazon S3 client for deletion.